### PR TITLE
Add AccountingReport object to handle new /accounting_reports endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.2.3
+-----
+- Add AccountingReport class to handle the new /accounting\_reports API endpoint
+
 1.2.2
 -----
 - Add API version setting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.2.3
+1.3.0
 -----
 - Add AccountingReport class to handle the new /accounting\_reports API endpoint
 

--- a/payplug/__init__.py
+++ b/payplug/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 from six import string_types
-from payplug import config, exceptions, network, notifications, resources, routes
-from payplug.network import HttpClient, UrllibRequest
+from payplug import config, exceptions, resources, routes
+from payplug.network import HttpClient
 from payplug.__version__ import __version__
 
 
@@ -28,6 +27,7 @@ def set_secret_key(token):
         raise exceptions.ConfigurationError('Expected string value for token.')
 
     config.secret_key = token
+
 
 def set_api_version(version):
     """
@@ -363,3 +363,37 @@ class Card(object):
         http_client = HttpClient()
         response, _ = http_client.get(routes.url(routes.CARD_RESOURCE, customer_id=customer, pagination=pagination))
         return resources.APIResourceCollection(resources.Card, **response)
+
+
+class AccountingReport:
+    """
+    A DAO for resources.AccountingReport which provides a way to query accounting reports.
+    """
+    @staticmethod
+    def retrieve(report_id):
+        """
+        Retrieve an accounting report from its id.
+
+        :param report_id: The report id
+        :type report_id: string
+
+        :return: The accounting report resource
+        :rtype: resources.AccountingReport
+        """
+        http_client = HttpClient()
+        response, __ = http_client.get(routes.url(routes.ACCOUNTING_REPORT_RESOURCE, resource_id=report_id))
+        return resources.AccountingReport(**response)
+
+    @staticmethod
+    def create(**data):
+        """
+        Create an accounting report.
+
+        :param data: data required to create the report
+
+        :return: The accounting report resource
+        :rtype resources.AccountingReport
+        """
+        http_client = HttpClient()
+        response, _ = http_client.post(routes.url(routes.ACCOUNTING_REPORT_RESOURCE), data)
+        return resources.AccountingReport(**response)

--- a/payplug/__version__.py
+++ b/payplug/__version__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.2.2'
+__version__ = '1.3.0'

--- a/payplug/resources.py
+++ b/payplug/resources.py
@@ -336,3 +336,21 @@ class APIResourceCollection(APIResource):
 
     def __getitem__(self, item):
         return self.data[item]
+
+
+class AccountingReport(APIResource, VerifiableAPIResource, ReconstituableAPIResource):
+    """
+    An accounting report.
+    """
+    object_type = 'accounting_report'
+
+    def get_consistent_resource(self):
+        """
+        :return an accounting report that you can trust.
+        :rtype AccountingReport
+        """
+        http_client = HttpClient()
+        response, _ = http_client.get(
+            routes.url(routes.ACCOUNTING_REPORT_RESOURCE, resource_id=self.id)
+        )
+        return AccountingReport(**response)

--- a/payplug/routes.py
+++ b/payplug/routes.py
@@ -6,6 +6,7 @@ PAYMENT_RESOURCE = '/payments'
 REFUND_RESOURCE = PAYMENT_RESOURCE + '/{payment_id}/refunds'
 CUSTOMER_RESOURCE = '/customers'
 CARD_RESOURCE = CUSTOMER_RESOURCE + '/{customer_id}/cards'
+ACCOUNTING_REPORT_RESOURCE = '/accounting_reports'
 
 # API base url
 API_BASE_URL = 'https://api.payplug.com'

--- a/payplug/test/test_init/test_dao_accounting_report.py
+++ b/payplug/test/test_init/test_dao_accounting_report.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from mock import patch
+import payplug
+from payplug import resources
+from payplug.test import TestBase
+
+
+@patch('payplug.config.secret_key', 'a_secret_key')
+@patch.object(payplug.HttpClient, 'post', lambda *args, **kwargs: ({'id': 'accounting_report_id'}, 201))
+@patch.object(payplug.HttpClient, 'get', lambda *args, **kwargs: ({'id': 'accounting_report_id'}, 200))
+class TestAccountingReportCreateRetrieve(TestBase):
+    def test_retrieve(self):
+        report = payplug.AccountingReport.retrieve('accounting_report_id')
+
+        assert isinstance(report, resources.AccountingReport)
+        assert report.id == 'accounting_report_id'
+
+    def test_create(self):
+        report = payplug.AccountingReport.create(some='report', da='ta')
+
+        assert isinstance(report, resources.AccountingReport)
+        assert report.id == 'accounting_report_id'

--- a/payplug/test/test_resources/test_accounting_report.py
+++ b/payplug/test/test_resources/test_accounting_report.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from mock import patch
+import payplug
+from payplug.resources import AccountingReport
+from payplug.test import TestBase
+
+
+@patch('payplug.config.secret_key', 'a_secret_key')
+class TestAccountingReportResource(TestBase):
+    def test_initialize_accounting_report(self):
+        report_attributes = {
+            'start_date': '2020-01-01',
+            'object': 'accounting_report',
+            'notification_url': 'notification_url',
+            'end_date': '2020-04-30',
+            'id': 'ar_1GKEACvltTVXT5muBd3AQv',
+            'file_available_until': 1588083743,
+            'temporary_url': 'temporary_url'
+        }
+
+        report_object = AccountingReport(**report_attributes)
+
+        assert report_object.id == 'ar_1GKEACvltTVXT5muBd3AQv'
+        assert report_object.start_date == '2020-01-01'
+        assert report_object.end_date == '2020-04-30'
+        assert report_object.notification_url == 'notification_url'
+        assert report_object.file_available_until == 1588083743
+        assert report_object.temporary_url == 'temporary_url'
+
+
+def report_fixture():
+    return {
+        "id": "ar_1GKEACvltTVXT5muBd3AQv",
+        "object": "accounting_report",
+    }
+
+
+@patch('payplug.config.secret_key', 'a_secret_key')
+@patch.object(payplug.HttpClient, 'get', lambda *args, **kwargs: (report_fixture(), 200))
+class TestConsistentAccountingReport(TestBase):
+    @patch('payplug.resources.routes.url')
+    def test_get_consistent_resource(self, routes_url_mock):
+        unsafe_report = AccountingReport(id='ar_1GKEACvltTVXT5muBd3AQv_unsafe',
+                                         object='accounting_report')
+        safe_report = unsafe_report.get_consistent_resource()
+
+        assert isinstance(safe_report, AccountingReport)
+        assert routes_url_mock.call_args[1]['resource_id'] == 'ar_1GKEACvltTVXT5muBd3AQv_unsafe'
+        assert safe_report.id == 'ar_1GKEACvltTVXT5muBd3AQv'

--- a/payplug/test/test_resources/test_accounting_report.py
+++ b/payplug/test/test_resources/test_accounting_report.py
@@ -15,7 +15,8 @@ class TestAccountingReportResource(TestBase):
             'end_date': '2020-04-30',
             'id': 'ar_1GKEACvltTVXT5muBd3AQv',
             'file_available_until': 1588083743,
-            'temporary_url': 'temporary_url'
+            'temporary_url': 'temporary_url',
+            'is_live': True
         }
 
         report_object = AccountingReport(**report_attributes)
@@ -26,6 +27,7 @@ class TestAccountingReportResource(TestBase):
         assert report_object.notification_url == 'notification_url'
         assert report_object.file_available_until == 1588083743
         assert report_object.temporary_url == 'temporary_url'
+        assert report_object.is_live == True
 
 
 def report_fixture():


### PR DESCRIPTION
Add a simple `AccountingReport` object (with `create()` and `retrieve()` methods) to handle the new endpoint.